### PR TITLE
Add support for browsing MIM packages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,30 @@
+<!DOCTYPE html>
 <html>
-<head>MongooseIM CT reports</head>
+
+<head>
+    <title>MongooseIM CircleCI results</title>
+</head>
+
 <body>
-Go to https://github.com/esl/circleci-mim-results to view a list of jobs.
-Each job has an index page https://github.com/esl/circleci-mim-results/JOB
-where JOB is string with two numbers 1234.1.
+    <h1>MongooseIM CircleCI results</h1>
+    <p>
+        <strong>Quick Links:</strong>
+    </p>
+    <ul>
+        <li><a href="s3_packages.html">View Binary Packages</a></li>
+        <li><a href="s3_reports.html">View Test Results</a></li>
+    </ul>
+    <hr>
+    <p>
+        Visit <a href="https://github.com/esl/circleci-mim-results" target="_blank">CircleCI MongooseIM Results</a>
+        to view a list of jobs. Each job has an index page:
+    </p>
+    <p>
+        <code>https://github.com/esl/circleci-mim-results/JOB</code>
+    </p>
+    <p>
+        Replace <code>JOB</code> with a string like <code>1234.1</code>.
+    </p>
 </body>
+
 </html>

--- a/list.js
+++ b/list.js
@@ -3,7 +3,7 @@ if (typeof S3BL_IGNORE_PATH == 'undefined' || S3BL_IGNORE_PATH!=true) {
 }
 
 if (typeof BUCKET_URL == 'undefined') {
-  var BUCKET_URL = location.protocol + '//' + location.hostname;
+  var BUCKET_URL = location.protocol + '//' + location.host;
 }
 
 if (typeof BUCKET_NAME != 'undefined') {
@@ -20,6 +20,40 @@ if (typeof BUCKET_WEBSITE_URL == 'undefined') {
 
 if (typeof S3B_ROOT_DIR == 'undefined') {
   var S3B_ROOT_DIR = '';
+}
+
+// Redirect logic for s3_packages.html
+if (location.pathname.indexOf('s3_packages.html') !== -1) {
+  var urlParams = location.search.substring(1).split('&');
+  var prefix = null;
+
+  for (var i = 0; i < urlParams.length; i++) {
+    var param = urlParams[i].split('=');
+    if (param[0] === 'prefix') {
+      prefix = decodeURIComponent(param[1]);
+      break;
+    }
+  }
+
+  if (prefix) {
+    var parts = prefix.split('/');
+    var lastPart = parts[parts.length - 1];
+    if (lastPart.indexOf('mim_') !== -1) {
+      var updatedLastPart = lastPart.replace('mim_', 'mongooseim_');
+      parts[parts.length - 1] = updatedLastPart;
+      var updatedPrefix = parts.join('/');
+      var redirectUrl = BUCKET_URL + '/' + updatedPrefix;
+
+      // Trigger download without rendering or leaving an empty page
+      var a = document.createElement('a');
+      a.href = redirectUrl;
+      a.download = updatedLastPart;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      document.body.innerHTML = '<p>Downloading ' + updatedLastPart + '...</p>';
+    }
+  }
 }
 
 jQuery(function($) {
@@ -174,7 +208,7 @@ function prepareTable(info) {
     item.keyText = item.Key.substring(prefix.length);
     if (item.Type === 'directory') {
       if (S3BL_IGNORE_PATH) {
-        item.href = location.protocol + '//' + location.hostname + location.pathname + '?prefix=' + item.Key;
+        item.href = location.protocol + '//' + location.host + location.pathname + '?prefix=' + item.Key;
       } else {
         item.href = item.keyText;
       }

--- a/s3_packages.html
+++ b/s3_packages.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-	<title>MongooseIM test results</title>
+	<title>MongooseIM binary packages</title>
 </head>
 
 <body>
@@ -11,7 +11,7 @@
 	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
 	<script type="text/javascript">
 		var S3BL_IGNORE_PATH = true;
-		var BUCKET_URL = '//circleci-mim-results.s3.eu-central-1.amazonaws.com';
+		var BUCKET_URL = '//mim-packages.s3.eu-central-1.amazonaws.com';
 		var S3B_ROOT_DIR = '';
 	</script>
 	<script src="list.js"></script>


### PR DESCRIPTION
This PR adds support for browsing and downloading MIM packages stored on S3. It also includes minor formatting and style improvements.

To download a package, you can use a link specific to the desired package, for example:  
`localhost:8000/s3_packages.html?prefix=branches/master/01dad37dc/mim_6.3.0_1.01dad37dc_otp_27.1.2~almalinux~8.10_amd64.rpm`

Alternatively, you can search for it through the webpage's file browser.

To test the changes locally, navigate to the project’s root folder and run:  
`python3 -m http.server 8000`